### PR TITLE
Add coverage to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ node_modules
 build
 *.node
 components
+coverage


### PR DESCRIPTION
Don't need the coverage stats in built npm packages.
